### PR TITLE
Update schedule_name 

### DIFF
--- a/lib/lambda_whenever/event_bridge_scheduler.rb
+++ b/lib/lambda_whenever/event_bridge_scheduler.rb
@@ -49,7 +49,8 @@ module LambdaWhenever
     end
 
     def schedule_name(task, option)
-      Digest::SHA1.hexdigest([option.key, task.expression, *task.commands].join("-")).to_s[0, 64]
+      input = "#{task.name}-#{Digest::SHA1.hexdigest([option.key, task.expression, *task.commands].join("-"))}"
+      sanitize_and_trim(input)
     end
 
     def schedule_description(task)
@@ -66,6 +67,14 @@ module LambdaWhenever
       end
     rescue Aws::Scheduler::Errors::ResourceNotFoundException
       puts "Schedule group '#{schedule_group}' does not exist."
+    end
+
+    private
+
+    def sanitize_and_trim(input)
+      sanitized = input.gsub(/[^a-zA-Z0-9\-._]/, "_")
+
+      sanitized[0, 64]
     end
   end
 end

--- a/lib/lambda_whenever/task.rb
+++ b/lib/lambda_whenever/task.rb
@@ -2,7 +2,7 @@
 
 module LambdaWhenever
   class Task
-    attr_reader :commands, :expression
+    attr_reader :commands, :expression, :name
 
     def initialize(environment, verbose, bundle_command, expression)
       @environment = environment
@@ -10,6 +10,7 @@ module LambdaWhenever
       @bundle_command = bundle_command.split(" ")
       @expression = expression
       @commands = []
+      @name = ""
     end
 
     def command(task)
@@ -17,14 +18,17 @@ module LambdaWhenever
     end
 
     def rake(task)
+      @name = task
       @commands << [@bundle_command, "rake", task, @verbose_mode].flatten.compact
     end
 
     def runner(src)
+      @name = src
       @commands << [@bundle_command, "rails", "runner", "-e", @environment, src].flatten
     end
 
     def script(script)
+      @name = script
       @commands << [@bundle_command, "script/#{script}"].flatten
     end
 

--- a/lib/lambda_whenever/version.rb
+++ b/lib/lambda_whenever/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaWhenever
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Update schedule_name method to include task name in EventBridge Scheduler registration

- Modified the schedule_name method to prepend task name to the SHA1 hash.
- Added sanitize_and_trim to ensure the final name is valid and trimmed to 64 characters.