### PR TITLE
add sync mode

### DIFF
--- a/lib/lambda_whenever/event_bridge_scheduler.rb
+++ b/lib/lambda_whenever/event_bridge_scheduler.rb
@@ -13,17 +13,60 @@ module LambdaWhenever
     def list_schedules(group_name)
       Logger.instance.message("Schedules in group '#{group_name}':")
       response = @scheduler_client.list_schedules({ group_name: group_name })
-      response.schedules.each do |schedule|
+      response.schedules.map do |schedule|
         detail = @scheduler_client.get_schedule({ group_name: group_name, name: schedule.name })
-        puts "#{schedule.state} #{schedule.name} #{detail.schedule_expression} #{detail.description}"
+        Logger.instance.message "#{schedule.state} #{schedule.name} #{detail.schedule_expression} #{detail.description}"
+        {
+          name: schedule.name,
+          state: schedule.state,
+          expression: detail.schedule_expression,
+          description: detail.description
+        }
+      end
+    end
+
+    def sync_schedules(desired_schedules, current_schedules, option)
+      desired_names = desired_schedules.map { |s| s[:name] }.to_set
+      current_schedules_hash = current_schedules.to_h do |schedule|
+        [schedule[:name], schedule]
+      end
+      current_names = current_schedules_hash.keys.to_set
+      to_delete = current_names - desired_names
+
+      to_add, to_update = desired_schedules.each_with_object([[], []]) do |desired, (add, update)|
+        current = current_schedules_hash[desired[:name]]
+        if current.nil?
+          add << desired
+        elsif schedules_differ?(current, desired, option)
+          update << desired
+        end
+      end
+
+      Logger.instance.message("Deleting #{to_delete.length} schedules...")
+      to_delete.each do |name|
+        Logger.instance.message "delete schedule: #{name}"
+        delete_schedule(name, option.scheduler_group)
+      end
+
+      Logger.instance.message("Creating #{to_add.length} schedules...")
+      to_add.each do |schedule|
+        Logger.instance.message "create schedule: #{schedule[:name]}"
+        create_schedule(schedule[:target], option)
+      end
+
+      Logger.instance.message("Updating #{to_update.length} schedules...")
+      to_update.each do |desired|
+        Logger.instance.message("Updating schedule: #{desired[:name]}")
+        delete_schedule(desired[:name], option.scheduler_group)
+        create_schedule(desired[:target], option)
       end
     end
 
     def create_schedule_group(group_name)
       @scheduler_client.create_schedule_group({ name: group_name })
-      puts "Schedule group '#{group_name}' created."
+      Logger.instance.message "Schedule group '#{group_name}' created."
     rescue Aws::Scheduler::Errors::ConflictException
-      puts "Schedule group '#{group_name}' already exists."
+      Logger.instance.message "Schedule group '#{group_name}' already exists."
     end
 
     # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Scheduler/Client.html#create_schedule-instance_method
@@ -60,21 +103,31 @@ module LambdaWhenever
     def clean_up_schedules(schedule_group)
       response = @scheduler_client.list_schedules({ group_name: schedule_group })
       response.schedules.each do |schedule|
-        @scheduler_client.delete_schedule({
-                                            name: schedule.name,
-                                            group_name: schedule_group
-                                          })
+        delete_schedule(schedule.name, schedule_group)
       end
-    rescue Aws::Scheduler::Errors::ResourceNotFoundException
-      puts "Schedule group '#{schedule_group}' does not exist."
     end
 
     private
 
     def sanitize_and_trim(input)
       sanitized = input.gsub(/[^a-zA-Z0-9\-._]/, "_")
-
       sanitized[0, 64]
+    end
+
+    def schedules_differ?(current, desired, option)
+      task = desired[:target].task
+      current[:expression] != task.expression ||
+        current[:description] != schedule_description(task) ||
+        current[:state] != option.rule_state
+    end
+
+    def delete_schedule(name, group_name)
+      @scheduler_client.delete_schedule({
+                                          name: name,
+                                          group_name: group_name
+                                        })
+    rescue Aws::Scheduler::Errors::ResourceNotFoundException
+      Logger.instance.message("Schedule '#{name}' does not exist.")
     end
   end
 end

--- a/lib/lambda_whenever/option.rb
+++ b/lib/lambda_whenever/option.rb
@@ -10,6 +10,7 @@ module LambdaWhenever
     CLEAR_MODE = 3
     LIST_MODE = 4
     PRINT_VERSION_MODE = 5
+    SYNC_MODE = 6
 
     attr_reader :mode, :verbose, :variables, :schedule_file, :iam_role, :rule_state,
                 :lambda_name, :scheduler_group
@@ -31,8 +32,11 @@ module LambdaWhenever
         opts.on("--dryrun", "dry-run") do
           @mode = DRYRUN_MODE
         end
-        opts.on("--update", "Creates and deletes tasks as needed by schedule file") do
+        opts.on("--update", "clear and create schedules") do
           @mode = UPDATE_MODE
+        end
+        opts.on("--sync", "Creates and deletes tasks as needed by schedule file") do
+          @mode = SYNC_MODE
         end
         opts.on("-c", "--clear", "Clear scheduled tasks") do
           @mode = CLEAR_MODE

--- a/lib/lambda_whenever/task.rb
+++ b/lib/lambda_whenever/task.rb
@@ -19,7 +19,7 @@ module LambdaWhenever
 
     def rake(task)
       @name = task
-      @commands << [@bundle_command, "rake", task, @verbose_mode].flatten.compact
+      @commands << [*@bundle_command, "rake", task, *@verbose_mode]
     end
 
     def runner(src)

--- a/lib/lambda_whenever/version.rb
+++ b/lib/lambda_whenever/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaWhenever
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
## 変更理由
従来のupdate modeは一度scheduleをclearしてから再登録を行う
これをデプロイ時に行うとclearから再登録までの間に実行したかったscheduleが実行されないことがありえる
scheduleをnameとgroupのタプルで登録済みとこれから登録するscheduleを比較し、
登録済みlistに存在しなければscheduleを追加、
登録するものlistに存在しなければscheduleの削除
を行う