### PR TITLE
fix README add "scheduler:GetSchedule"

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The following policy grants the required permissions:
       "Action": [
         "scheduler:CreateScheduleGroup",
         "scheduler:ListSchedules",
+        "scheduler:GetSchedule",
         "scheduler:CreateSchedule",
         "scheduler:DeleteSchedule",
         "scheduler:UpdateSchedule",


### PR DESCRIPTION
- #6
でscheduler:GetScheduleの権限が必要になった