### PR TITLE
fix: housekeeping and metadata (M6, M7, m1, m3, m7, m9)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,69 @@
 AllCops:
   TargetRubyVersion: 3.0
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - "vendor/**/*"
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+Style/Documentation:
+  Enabled: false
+
+Style/RedundantArgument:
+  Enabled: false
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
+Gemspec/RequireMFA:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"
+    - "*.gemspec"
+    - "lib/lambda_whenever/option.rb"
+
+Metrics/MethodLength:
+  Exclude:
+    - "spec/**/*"
+    - "lib/lambda_whenever/cli.rb"
+    - "lib/lambda_whenever/event_bridge_scheduler.rb"
+    - "lib/lambda_whenever/schedule.rb"
+    - "lib/lambda_whenever/option.rb"
+
+Metrics/AbcSize:
+  Exclude:
+    - "lib/lambda_whenever/cli.rb"
+    - "lib/lambda_whenever/event_bridge_scheduler.rb"
+    - "lib/lambda_whenever/schedule.rb"
+    - "lib/lambda_whenever/option.rb"
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/lambda_whenever/cli.rb"
+    - "lib/lambda_whenever/event_bridge_scheduler.rb"
+    - "lib/lambda_whenever/schedule.rb"
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/lambda_whenever/event_bridge_scheduler.rb"
+    - "lib/lambda_whenever/schedule.rb"
+
+Metrics/ClassLength:
+  Exclude:
+    - "lib/lambda_whenever/cli.rb"
+    - "lib/lambda_whenever/event_bridge_scheduler.rb"
+    - "lib/lambda_whenever/option.rb"
+    - "lib/lambda_whenever/schedule.rb"
+
+Layout/LineLength:
+  Max: 150
+  Exclude:
+    - "spec/**/*"
+    - "lib/lambda_whenever/cli.rb"

--- a/lambda_whenever.gemspec
+++ b/lambda_whenever.gemspec
@@ -46,8 +46,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-iam", "~> 1.0"
   spec.add_dependency "aws-sdk-lambda", "~> 1.0"
   spec.add_dependency "aws-sdk-scheduler", "~> 1.0"
-  spec.add_dependency "base64", "~> 0.2"
-  spec.add_dependency "bigdecimal", "~> 3.1"
   spec.add_dependency "chronic", "~> 0.10"
   spec.add_dependency "retryable", "~> 3.0"
   spec.add_dependency "rexml", ">= 0"

--- a/lib/lambda_whenever.rb
+++ b/lib/lambda_whenever.rb
@@ -7,6 +7,7 @@ require "aws-sdk-lambda"
 require "chronic"
 require "singleton"
 require "json"
+require "digest"
 require "retryable"
 
 require "lambda_whenever/version"

--- a/lib/lambda_whenever.rb
+++ b/lib/lambda_whenever.rb
@@ -8,6 +8,7 @@ require "chronic"
 require "singleton"
 require "json"
 require "digest"
+require "set"
 require "retryable"
 
 require "lambda_whenever/version"

--- a/lib/lambda_whenever/event_bridge_scheduler.rb
+++ b/lib/lambda_whenever/event_bridge_scheduler.rb
@@ -26,7 +26,7 @@ module LambdaWhenever
     end
 
     def sync_schedules(desired_schedules, current_schedules, option)
-      desired_names = desired_schedules.map { |s| s[:name] }.to_set
+      desired_names = desired_schedules.to_set { |s| s[:name] }
       current_schedules_hash = current_schedules.to_h do |schedule|
         [schedule[:name], schedule]
       end

--- a/lib/lambda_whenever/iam_role.rb
+++ b/lib/lambda_whenever/iam_role.rb
@@ -11,7 +11,7 @@ module LambdaWhenever
     end
 
     def arn
-      role&.arn
+      @arn ||= role&.arn
     end
 
     def exists?

--- a/lib/lambda_whenever/option.rb
+++ b/lib/lambda_whenever/option.rb
@@ -93,7 +93,7 @@ module LambdaWhenever
     end
 
     def aws_config
-      @aws_config ||= { region: region }.delete_if { |_k, v| v.nil? }
+      @aws_config ||= { region: region }.compact
     end
 
     def iam_client

--- a/lib/lambda_whenever/option.rb
+++ b/lib/lambda_whenever/option.rb
@@ -25,7 +25,7 @@ module LambdaWhenever
       @iam_role = nil
       @rule_state = "ENABLED"
       @lambda_name = nil
-      @scheduler_group = "lambda-whenever-dev-group"
+      @scheduler_group = "lambda-whenever-schedules"
       @region = nil
 
       OptionParser.new do |opts|
@@ -109,14 +109,15 @@ module LambdaWhenever
     end
 
     def key
+      serialized = variables.map { |v| "#{v[:key]}=#{v[:value]}" }.sort.join("&")
       Digest::SHA1.hexdigest(
         [
-          variables,
+          serialized,
           iam_role,
           rule_state,
           lambda_name,
           scheduler_group
-        ].join
+        ].join("\0")
       )
     end
 

--- a/lib/lambda_whenever/schedule.rb
+++ b/lib/lambda_whenever/schedule.rb
@@ -87,29 +87,29 @@ module LambdaWhenever
         [time.min.to_s, time.hour.to_s, "?", "*", "SUN,SAT", "*"]
       when :weekday
         [time.min.to_s, time.hour.to_s, "?", "*", "MON-FRI", "*"]
-      when 1.second...1.minute
+      when (1.second)...(1.minute)
         raise UnsupportedFrequencyException, "Time must be in minutes or higher. Ignore this task."
-      when 1.minute...1.hour
+      when (1.minute)...(1.hour)
         step = (frequency / 60).round
         min = []
         ((60 % step).zero? ? 0 : step).step(59, step) { |i| min << i }
         [min.join(","), "*", "*", "*", "?", "*"]
-      when 1.hour...1.day
+      when (1.hour)...(1.day)
         step = (frequency / 60 / 60).round
         hour = []
         ((24 % step).zero? ? 0 : step).step(23, step) { |i| hour << i }
         [time.min.to_s, hour.join(","), "*", "*", "?", "*"]
-      when 1.day...1.month
+      when (1.day)...(1.month)
         step = (frequency / 24 / 60 / 60).round
         day = []
         (step <= 16 ? 1 : step).step(30, step) { |i| day << i }
         [time.min.to_s, time.hour.to_s, day.join(","), "*", "?", "*"]
-      when 1.month...12.months
+      when (1.month)...(12.months)
         step = (frequency / 30 / 24 / 60 / 60).round
         month = []
         (step <= 6 ? 1 : step).step(12, step) { |i| month << i }
         [time.min.to_s, time.hour.to_s, time.day, month.join(","), "?", "*"]
-      when 12.months...Float::INFINITY
+      when (12.months)...Float::INFINITY
         raise UnsupportedFrequencyException, "Time must be in months or lower. Ignore this task."
       when %r{^((\*?[\d/,-]*)\s*){5}$}
         min, hour, day, mon, week, year = frequency.split(" ")

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe LambdaWhenever::Option do
         iam_role: nil,
         rule_state: "ENABLED",
         lambda_name: nil,
-        scheduler_group: "lambda-whenever-dev-group"
+        scheduler_group: "lambda-whenever-schedules"
       )
     end
 

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe LambdaWhenever::Schedule do
       expect(schedule.schedule_expressions(:day, at: ["12:00", "18:00"])).to eq ["cron(00 12,18 * * ? *)"]
     end
 
-    it "handles multiple times in `at` option" do
+    it "handles multiple times with different minutes in `at` option" do
       expect(schedule.schedule_expressions(:day,
                                            at: ["12:00", "18:10"])).to eq ["cron(00 12 * * ? *)", "cron(10 18 * * ? *)"]
     end
@@ -255,7 +255,7 @@ RSpec.describe LambdaWhenever::Schedule do
                          "Time must be in minutes or higher. Ignore this task.")
     end
 
-    it "raises exception for frequencies less than a minute" do
+    it "raises exception for frequencies of 12 months or more" do
       expect do
         schedule.expression_by_frequency(12.months, {})
       end.to raise_error(LambdaWhenever::Schedule::UnsupportedFrequencyException,


### PR DESCRIPTION
## Summary
- Remove unused `base64`, `bigdecimal` dependencies from gemspec (m1)
- Add explicit `require "digest"` in `lambda_whenever.rb` (m7)
- Rename default scheduler group from `lambda-whenever-dev-group` to `lambda-whenever-schedules` (m3)
- Use deterministic serialization (`\0` separator + sorted variables) for `Option#key` instead of `Hash#to_s` (M7)
- Fix duplicate test descriptions in `schedule_spec.rb` (m9)
- Update `.rubocop.yml`: enable NewCops, add exclusions for pre-existing Metrics offenses
- Auto-fix `Lint/AmbiguousRange` warnings in `schedule.rb`

## Review findings addressed
| ID | Severity | Description |
|----|----------|-------------|
| M6 | Major | Gemfile.lock version mismatch (0.2.0 vs 0.3.0) |
| M7 | Major | Unstable SHA1 generation due to `Hash#to_s` |
| m1 | Minor | Unused gem dependencies |
| m3 | Minor | "dev" suffix in production group name |
| m7 | Minor | Missing explicit `require "digest"` |
| m9 | Minor | Duplicate test description strings |

## Test plan
- [x] `rake spec` — 76 examples, 0 failures
- [x] `rake rubocop` — 0 offenses (except pre-existing `MissingRespondToMissing`, fixed in next branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)