### PR TITLE
fix: add respond_to_missing? and namespace WheneverNumeric (C2, m8)

### DIFF
--- a/lib/lambda_whenever/schedule.rb
+++ b/lib/lambda_whenever/schedule.rb
@@ -8,7 +8,7 @@ module LambdaWhenever
 
     class UnsupportedFrequencyException < StandardError; end
 
-    using WheneverNumeric
+    using LambdaWhenever::WheneverNumeric
 
     def initialize(file, verbose, variables)
       @environment = "production"
@@ -137,6 +137,10 @@ module LambdaWhenever
 
     def method_missing(name, *_args)
       Logger.instance.warn("Skipping unsupported method: #{name}")
+    end
+
+    def respond_to_missing?(_name, _include_private = false)
+      true
     end
   end
 end

--- a/lib/lambda_whenever/task.rb
+++ b/lib/lambda_whenever/task.rb
@@ -35,5 +35,9 @@ module LambdaWhenever
     def method_missing(name, *_args)
       Logger.instance.warn("Skipping unsupported method: #{name}")
     end
+
+    def respond_to_missing?(_name, _include_private = false)
+      true
+    end
   end
 end

--- a/lib/lambda_whenever/whenever_numeric.rb
+++ b/lib/lambda_whenever/whenever_numeric.rb
@@ -1,40 +1,42 @@
 # frozen_string_literal: true
 
-module WheneverNumeric
-  refine Numeric do
-    def seconds
-      self
-    end
-    alias_method :second, :seconds
+module LambdaWhenever
+  module WheneverNumeric
+    refine Numeric do
+      def seconds
+        self
+      end
+      alias_method :second, :seconds
 
-    def minutes
-      self * 60
-    end
-    alias_method :minute, :minutes
+      def minutes
+        self * 60
+      end
+      alias_method :minute, :minutes
 
-    def hours
-      (self * 60).minutes
-    end
-    alias_method :hour, :hours
+      def hours
+        (self * 60).minutes
+      end
+      alias_method :hour, :hours
 
-    def days
-      (self * 24).hours
-    end
-    alias_method :day, :days
+      def days
+        (self * 24).hours
+      end
+      alias_method :day, :days
 
-    def weeks
-      (self * 7).days
-    end
-    alias_method :week, :weeks
+      def weeks
+        (self * 7).days
+      end
+      alias_method :week, :weeks
 
-    def months
-      (self * 30).days
-    end
-    alias_method :month, :months
+      def months
+        (self * 30).days
+      end
+      alias_method :month, :months
 
-    def years
-      (self * 365.25).days
+      def years
+        (self * 365.25).days
+      end
+      alias_method :year, :years
     end
-    alias_method :year, :years
   end
 end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require "lambda_whenever/whenever_numeric"
 
 RSpec.describe LambdaWhenever::Schedule do
-  using WheneverNumeric
+  using LambdaWhenever::WheneverNumeric
   let(:schedule) { LambdaWhenever::Schedule.new(Pathname(__dir__).join("fixtures/schedule.rb").to_s, false, []) }
 
   describe "#initialize" do


### PR DESCRIPTION
## Summary
- Add `respond_to_missing?` to `Schedule` and `Task` classes to comply with Ruby's `method_missing` protocol (C2)
- Move `WheneverNumeric` refinement module into `LambdaWhenever` namespace (m8)
- Update `using` statements in `schedule.rb` and `schedule_spec.rb`

## Review findings addressed
| ID | Severity | Description |
|----|----------|-------------|
| C2 | Critical | Missing `respond_to_missing?` with `method_missing` — violates Ruby object protocol, silently swallows typos |
| m8 | Minor | `WheneverNumeric` defined outside `LambdaWhenever` namespace |

## Test plan
- [x] `rake spec` — 76 examples, 0 failures
- [x] `rake rubocop` — 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)