### PR TITLE
fix: schedule security hardening (C1, C4, m6)

### DIFF
--- a/lib/lambda_whenever/schedule.rb
+++ b/lib/lambda_whenever/schedule.rb
@@ -32,9 +32,7 @@ module LambdaWhenever
         Logger.instance.warn("Cannot overwrite reserved key '#{key}' via set")
         return
       end
-      unless ALLOWED_SET_KEYS.include?(key)
-        Logger.instance.warn("Setting non-standard key '#{key}'; consider using an ALLOWED key: #{ALLOWED_SET_KEYS.join(", ")}")
-      end
+      Logger.instance.warn("Setting non-standard key '#{key}'. Allowed: #{ALLOWED_SET_KEYS.join(", ")}") unless ALLOWED_SET_KEYS.include?(key)
       instance_variable_set("@#{key}", value)
     end
 
@@ -152,6 +150,7 @@ module LambdaWhenever
     def validate_file!(file)
       path = File.expand_path(file)
       raise ArgumentError, "Schedule file does not exist: #{file}" unless File.exist?(path)
+      raise ArgumentError, "Schedule file must be a regular file: #{file}" unless File.file?(path)
       raise ArgumentError, "Schedule file must have .rb extension: #{file}" unless path.end_with?(".rb")
     end
 

--- a/lib/lambda_whenever/schedule.rb
+++ b/lib/lambda_whenever/schedule.rb
@@ -6,6 +6,9 @@ module LambdaWhenever
   class Schedule
     attr_reader :tasks, :chronic_options, :bundle_command, :environment, :timezone
 
+    ALLOWED_SET_KEYS = %w[environment bundle_command chronic_options timezone].freeze
+    RESERVED_SET_KEYS = %w[tasks verbose].freeze
+
     class UnsupportedFrequencyException < StandardError; end
 
     using LambdaWhenever::WheneverNumeric
@@ -17,13 +20,22 @@ module LambdaWhenever
       @chronic_options = {}
       @bundle_command = "bundle exec"
 
+      validate_file!(file)
       variables.each { |var| set(var[:key], var[:value]) }
       instance_eval(File.read(file), file)
       @timezone ||= "UTC"
     end
 
     def set(key, value)
-      instance_variable_set("@#{key}", value) unless key == "tasks"
+      key = key.to_s
+      if RESERVED_SET_KEYS.include?(key)
+        Logger.instance.warn("Cannot overwrite reserved key '#{key}' via set")
+        return
+      end
+      unless ALLOWED_SET_KEYS.include?(key)
+        Logger.instance.warn("Setting non-standard key '#{key}'; consider using an ALLOWED key: #{ALLOWED_SET_KEYS.join(", ")}")
+      end
+      instance_variable_set("@#{key}", value)
     end
 
     def every(frequency, options = {}, &block)
@@ -131,8 +143,16 @@ module LambdaWhenever
 
     def print_tasks
       @tasks.each do |task|
-        puts "#{task.expression} { commands: #{task.commands} }"
+        Logger.instance.message("#{task.expression} { commands: #{task.commands} }")
       end
+    end
+
+    private
+
+    def validate_file!(file)
+      path = File.expand_path(file)
+      raise ArgumentError, "Schedule file does not exist: #{file}" unless File.exist?(path)
+      raise ArgumentError, "Schedule file must have .rb extension: #{file}" unless path.end_with?(".rb")
     end
 
     def method_missing(name, *_args)

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "lambda_whenever/whenever_numeric"
+require "tempfile"
 
 RSpec.describe LambdaWhenever::Schedule do
   using LambdaWhenever::WheneverNumeric
@@ -164,16 +165,23 @@ RSpec.describe LambdaWhenever::Schedule do
   end
 
   describe "#set" do
-    it "sets value" do
+    it "sets allowed key value" do
       expect do
-        schedule.set("foo", "bar")
-      end.to change { schedule.instance_variable_get("@foo") }.from(nil).to("bar")
+        schedule.set("environment", "staging")
+      end.to change { schedule.instance_variable_get("@environment") }.from("production").to("staging")
     end
 
     it "does not set `tasks` value" do
       expect do
         schedule.set("tasks", "some value")
       end.not_to(change { schedule.tasks })
+    end
+
+    it "sets non-standard key with warning" do
+      logger = LambdaWhenever::Logger.instance
+      expect(logger).to receive(:warn).with(/non-standard key/)
+      schedule.set("foo", "bar")
+      expect(schedule.instance_variable_get("@foo")).to eq("bar")
     end
   end
 
@@ -272,11 +280,53 @@ RSpec.describe LambdaWhenever::Schedule do
   end
 
   describe "#print_tasks" do
-    it "prints tasks" do
-      allow(schedule).to receive(:puts)
-      expect(schedule).to receive(:puts).with('cron(0 3 * * ? *) { commands: [["bundle", "exec", "rails", "runner", "-e", "production", "Hoge.run"]] }')
-      expect(schedule).to receive(:puts).with('cron(0 0 1 * ? *) { commands: [["bundle", "exec", "rake", "hoge:run", "--silent"], ["bundle", "exec", "rails", "runner", "-e", "production", "Fuga.run"]] }')
+    it "prints tasks via Logger" do
+      logger = LambdaWhenever::Logger.instance
+      expect(logger).to receive(:message).with('cron(0 3 * * ? *) { commands: [["bundle", "exec", "rails", "runner", "-e", "production", "Hoge.run"]] }')
+      expect(logger).to receive(:message).with('cron(0 0 1 * ? *) { commands: [["bundle", "exec", "rake", "hoge:run", "--silent"], ["bundle", "exec", "rails", "runner", "-e", "production", "Fuga.run"]] }')
       schedule.print_tasks
+    end
+  end
+
+  describe "#set security" do
+    it "rejects reserved key 'tasks'" do
+      original_tasks = schedule.tasks
+      schedule.set("tasks", "malicious")
+      expect(schedule.tasks).to eq(original_tasks)
+    end
+
+    it "rejects reserved key 'verbose'" do
+      schedule.set("verbose", true)
+      expect(schedule.instance_variable_get(:@verbose)).to be false
+    end
+
+    it "warns about non-standard keys" do
+      logger = LambdaWhenever::Logger.instance
+      expect(logger).to receive(:warn).with(/non-standard key/)
+      schedule.set("custom_key", "value")
+    end
+
+    it "allows standard keys without warning" do
+      logger = LambdaWhenever::Logger.instance
+      expect(logger).not_to receive(:warn)
+      schedule.set("environment", "staging")
+      expect(schedule.environment).to eq("staging")
+    end
+  end
+
+  describe "file validation" do
+    it "raises error for non-existent file" do
+      expect do
+        LambdaWhenever::Schedule.new("/nonexistent/file.rb", false, [])
+      end.to raise_error(ArgumentError, /does not exist/)
+    end
+
+    it "raises error for non-.rb file" do
+      tmpfile = Tempfile.new(["schedule", ".txt"])
+      expect do
+        LambdaWhenever::Schedule.new(tmpfile.path, false, [])
+      end.to raise_error(ArgumentError, /must have .rb extension/)
+      tmpfile.unlink
     end
   end
 end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -183,6 +183,11 @@ RSpec.describe LambdaWhenever::Schedule do
       schedule.set("foo", "bar")
       expect(schedule.instance_variable_get("@foo")).to eq("bar")
     end
+
+    it "accepts symbol keys" do
+      schedule.set(:environment, "staging")
+      expect(schedule.environment).to eq("staging")
+    end
   end
 
   describe "#schedule_expressions" do
@@ -322,11 +327,19 @@ RSpec.describe LambdaWhenever::Schedule do
     end
 
     it "raises error for non-.rb file" do
-      tmpfile = Tempfile.new(["schedule", ".txt"])
-      expect do
-        LambdaWhenever::Schedule.new(tmpfile.path, false, [])
-      end.to raise_error(ArgumentError, /must have .rb extension/)
-      tmpfile.unlink
+      Tempfile.create(["schedule", ".txt"]) do |tmpfile|
+        expect do
+          LambdaWhenever::Schedule.new(tmpfile.path, false, [])
+        end.to raise_error(ArgumentError, /must have .rb extension/)
+      end
+    end
+
+    it "raises error for directory path with .rb extension" do
+      Dir.mktmpdir("schedule.rb") do |dir|
+        expect do
+          LambdaWhenever::Schedule.new(dir, false, [])
+        end.to raise_error(ArgumentError, /must be a regular file/)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add file path validation in `Schedule#initialize`: check existence and `.rb` extension before `instance_eval` (C1)
- Protect `set` method with `RESERVED_SET_KEYS` (reject `tasks`, `verbose`) and warn on non-standard keys for backward compatibility (C4)
- Replace `puts` with `Logger.instance.message` in `print_tasks` for consistent output (m6)
- Add tests for set security, file validation, and Logger-based output

## Review findings addressed
| ID | Severity | Description |
|----|----------|-------------|
| C1 | Critical | `instance_eval` security risk — no file path validation before loading |
| C4 | Critical | Arbitrary instance variable overwrites via `set` method |
| m6 | Minor | Inconsistent `puts` vs `Logger` usage |

## Design decisions
- `set` accepts non-standard keys with a warning (backward compatible) but rejects reserved keys (`tasks`, `verbose`)
- File validation checks both existence and `.rb` extension

## Test plan
- [x] `rake spec` — 83 examples, 0 failures (+7 new tests)
- [x] `rake rubocop` — 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)