### PR TITLE
fix: task command safety and schedule name truncation (m5, m11)

### DIFF
--- a/lib/lambda_whenever/event_bridge_scheduler.rb
+++ b/lib/lambda_whenever/event_bridge_scheduler.rb
@@ -91,9 +91,15 @@ module LambdaWhenever
                                         })
     end
 
+    # SHA1 hex digest is 40 chars, separator is 1 char, so prefix max is 64 - 41 = 23 chars
+    SCHEDULE_NAME_MAX_LENGTH = 64
+    SHA1_HEX_LENGTH = 40
+    PREFIX_MAX_LENGTH = SCHEDULE_NAME_MAX_LENGTH - SHA1_HEX_LENGTH - 1
+
     def schedule_name(task, option)
-      input = "#{task.name}-#{Digest::SHA1.hexdigest([option.key, task.expression, *task.commands].join("-"))}"
-      sanitize_and_trim(input)
+      hash = Digest::SHA1.hexdigest([option.key, task.expression, *task.commands].join("-"))
+      prefix = sanitize(task.name)[0, PREFIX_MAX_LENGTH]
+      "#{prefix}-#{hash}"
     end
 
     def schedule_description(task)
@@ -109,9 +115,8 @@ module LambdaWhenever
 
     private
 
-    def sanitize_and_trim(input)
-      sanitized = input.gsub(/[^a-zA-Z0-9\-._]/, "_")
-      sanitized[0, 64]
+    def sanitize(input)
+      input.gsub(/[^a-zA-Z0-9\-._]/, "_")
     end
 
     def schedules_differ?(current, desired, option)

--- a/lib/lambda_whenever/event_bridge_scheduler.rb
+++ b/lib/lambda_whenever/event_bridge_scheduler.rb
@@ -3,6 +3,13 @@
 module LambdaWhenever
   # The EventBridgeScheduler class is responsible for managing schedules in AWS EventBridge.
   class EventBridgeScheduler
+    # SHA1 hex digest is 40 chars, separator is 1 char, so prefix max is 64 - 41 = 23 chars.
+    # Prefix may be truncated mid-word; multibyte characters are sanitized to underscores.
+    SCHEDULE_NAME_MAX_LENGTH = 64
+    SHA1_HEX_LENGTH = 40
+    PREFIX_MAX_LENGTH = SCHEDULE_NAME_MAX_LENGTH - SHA1_HEX_LENGTH - 1
+    DEFAULT_SCHEDULE_PREFIX = "task"
+
     attr_reader :timezone
 
     def initialize(client, timezone = "UTC")
@@ -91,21 +98,6 @@ module LambdaWhenever
                                         })
     end
 
-    # SHA1 hex digest is 40 chars, separator is 1 char, so prefix max is 64 - 41 = 23 chars
-    SCHEDULE_NAME_MAX_LENGTH = 64
-    SHA1_HEX_LENGTH = 40
-    PREFIX_MAX_LENGTH = SCHEDULE_NAME_MAX_LENGTH - SHA1_HEX_LENGTH - 1
-
-    def schedule_name(task, option)
-      hash = Digest::SHA1.hexdigest([option.key, task.expression, *task.commands].join("-"))
-      prefix = sanitize(task.name)[0, PREFIX_MAX_LENGTH]
-      "#{prefix}-#{hash}"
-    end
-
-    def schedule_description(task)
-      task.commands.to_s
-    end
-
     def clean_up_schedules(schedule_group)
       response = @scheduler_client.list_schedules({ group_name: schedule_group })
       response.schedules.each do |schedule|
@@ -114,6 +106,17 @@ module LambdaWhenever
     end
 
     private
+
+    def schedule_name(task, option)
+      hash = Digest::SHA1.hexdigest([option.key, task.expression, *task.commands].join("-"))
+      raw_prefix = task.name.to_s.empty? ? DEFAULT_SCHEDULE_PREFIX : task.name
+      prefix = sanitize(raw_prefix)[0, PREFIX_MAX_LENGTH]
+      "#{prefix}-#{hash}"
+    end
+
+    def schedule_description(task)
+      task.commands.to_s
+    end
 
     def sanitize(input)
       input.gsub(/[^a-zA-Z0-9\-._]/, "_")

--- a/lib/lambda_whenever/task.rb
+++ b/lib/lambda_whenever/task.rb
@@ -9,14 +9,14 @@ module LambdaWhenever
     def initialize(environment, verbose, bundle_command, expression)
       @environment = environment
       @verbose_mode = verbose ? nil : "--silent"
-      @bundle_command = Shellwords.split(bundle_command)
+      @bundle_command = safe_shellwords_split(bundle_command)
       @expression = expression
       @commands = []
       @name = ""
     end
 
     def command(task)
-      @commands << Shellwords.split(task)
+      @commands << safe_shellwords_split(task)
     end
 
     def rake(task)
@@ -40,6 +40,14 @@ module LambdaWhenever
 
     def respond_to_missing?(_name, _include_private = false)
       true
+    end
+
+    private
+
+    def safe_shellwords_split(str)
+      Shellwords.split(str)
+    rescue ArgumentError => e
+      raise ArgumentError, "Invalid command syntax: #{str.inspect} (#{e.message})"
     end
   end
 end

--- a/lib/lambda_whenever/task.rb
+++ b/lib/lambda_whenever/task.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "shellwords"
+
 module LambdaWhenever
   class Task
     attr_reader :commands, :expression, :name
@@ -7,14 +9,14 @@ module LambdaWhenever
     def initialize(environment, verbose, bundle_command, expression)
       @environment = environment
       @verbose_mode = verbose ? nil : "--silent"
-      @bundle_command = bundle_command.split(" ")
+      @bundle_command = Shellwords.split(bundle_command)
       @expression = expression
       @commands = []
       @name = ""
     end
 
     def command(task)
-      @commands << task.split(" ")
+      @commands << Shellwords.split(task)
     end
 
     def rake(task)

--- a/spec/event_bridge_scheduler_spec.rb
+++ b/spec/event_bridge_scheduler_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "digest"
+
+RSpec.describe LambdaWhenever::EventBridgeScheduler do
+  let(:scheduler_client) { double("Aws::Scheduler::Client") }
+  let(:scheduler) { described_class.new(scheduler_client) }
+
+  describe "#schedule_name (via create_schedule)" do
+    let(:option) { double("Option", key: "test-key") }
+
+    def build_task(name, expression, commands)
+      double("Task", name: name, expression: expression, commands: commands)
+    end
+
+    def compute_schedule_name(task, option)
+      scheduler.send(:schedule_name, task, option)
+    end
+
+    context "with a normal task name" do
+      it "fits within 64 characters" do
+        task = build_task("my_task", "cron(0 0 * * ? *)", [%w[bundle exec rake db:migrate]])
+        name = compute_schedule_name(task, option)
+
+        expect(name.length).to be <= 64
+      end
+
+      it "preserves the full SHA1 hash (40 chars)" do
+        task = build_task("my_task", "cron(0 0 * * ? *)", [%w[bundle exec rake db:migrate]])
+        name = compute_schedule_name(task, option)
+        hash_part = name.split("-", 2).last
+
+        expect(hash_part).to match(/\A[a-f0-9]{40}\z/)
+      end
+
+      it "includes the sanitized task name as prefix" do
+        task = build_task("deploy", "cron(0 0 * * ? *)", [%w[deploy run]])
+        name = compute_schedule_name(task, option)
+
+        expect(name).to start_with("deploy-")
+      end
+    end
+
+    context "with a long task name" do
+      it "truncates the prefix to 23 characters" do
+        long_name = "a" * 50
+        task = build_task(long_name, "cron(0 0 * * ? *)", [%w[rake run]])
+        name = compute_schedule_name(task, option)
+
+        prefix = name.split("-", 2).first
+        expect(prefix.length).to eq(described_class::PREFIX_MAX_LENGTH)
+        expect(name.length).to eq(64)
+      end
+    end
+
+    context "with an empty task name" do
+      it "uses the default prefix" do
+        task = build_task("", "cron(0 0 * * ? *)", [%w[echo hello]])
+        name = compute_schedule_name(task, option)
+
+        expect(name).to start_with("#{described_class::DEFAULT_SCHEDULE_PREFIX}-")
+        expect(name.length).to be <= 64
+      end
+    end
+
+    context "with special characters in task name" do
+      it "sanitizes non-alphanumeric characters to underscores" do
+        task = build_task("my task@v2!", "cron(0 0 * * ? *)", [%w[run]])
+        name = compute_schedule_name(task, option)
+
+        prefix = name.split("-", 2).first
+        expect(prefix).to eq("my_task_v2_")
+      end
+    end
+
+    context "with the same inputs" do
+      it "produces deterministic names" do
+        task = build_task("deploy", "cron(0 0 * * ? *)", [%w[deploy run]])
+        name1 = compute_schedule_name(task, option)
+        name2 = compute_schedule_name(task, option)
+
+        expect(name1).to eq(name2)
+      end
+    end
+
+    context "with different inputs" do
+      it "produces different hashes" do
+        task1 = build_task("deploy", "cron(0 0 * * ? *)", [%w[deploy run]])
+        task2 = build_task("deploy", "cron(0 12 * * ? *)", [%w[deploy run]])
+        name1 = compute_schedule_name(task1, option)
+        name2 = compute_schedule_name(task2, option)
+
+        expect(name1).not_to eq(name2)
+      end
+    end
+  end
+end

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe LambdaWhenever::Task do
       task.command("echo 'hello world' --flag")
       expect(task.commands).to eq([["echo", "hello world", "--flag"]])
     end
+
+    it "raises ArgumentError for unclosed quotes" do
+      expect { task.command("echo 'hello") }.to raise_error(ArgumentError, /Invalid command syntax/)
+    end
   end
 
   describe "#rake" do
@@ -77,6 +81,17 @@ RSpec.describe LambdaWhenever::Task do
         task.script("runner.rb")
         expect(task.commands).to eq([%w[script/runner.rb]])
       end
+    end
+  end
+
+  describe "#initialize with quoted bundle_command" do
+    let(:task) do
+      LambdaWhenever::Task.new("production", false, "bundle exec --path 'my gems'", "cron(0 17 * * ? *)")
+    end
+
+    it "parses quoted bundle_command arguments" do
+      task.rake("hoge:run")
+      expect(task.commands).to eq([["bundle", "exec", "--path", "my gems", "rake", "hoge:run", "--silent"]])
     end
   end
 

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe LambdaWhenever::Task do
       task.command("hoge fuga bar:baz")
       expect(task.commands).to eq([%w[hoge fuga bar:baz]])
     end
+
+    it "handles quoted arguments with spaces" do
+      task.command("echo 'hello world' --flag")
+      expect(task.commands).to eq([["echo", "hello world", "--flag"]])
+    end
   end
 
   describe "#rake" do


### PR DESCRIPTION
## 概要
- `String#split(" ")` の代わりに `Shellwords.split` を使用し、シェル引数を正しくパース (m5)
- スケジュール名のプレフィックスを23文字に制限し、64文字制限内でSHA1ハッシュ全体(40文字)を保証 (m11)
- 定数をクラス先頭に移動し、`schedule_name`/`schedule_description` を `private` に移動
- `task.name` が空の場合のフォールバックを追加し、ハイフン始まりのスケジュール名を防止
- `safe_shellwords_split` を追加し、未閉じクォート時に明確な `ArgumentError` メッセージを提供
- `event_bridge_scheduler_spec.rb` を新規作成し、`schedule_name` のユニットテストを追加
- クォート付き `bundle_command` 引数と未閉じクォートエラーのテストを追加

## 対応した指摘事項
| ID | 重要度 | 内容 |
|----|--------|------|
| m5 | Minor | `String#split` がクォート付きスペース含む引数を壊す |
| m11 | Minor | スケジュール名の切り詰めでSHA1ハッシュが失われる可能性 |
| review-1 | Must Fix | 定数の配置と `schedule_name` の可視性 |
| review-2 | Must Fix | 空の `task.name` でハイフン始まりのスケジュール名が生成される |
| review-3 | Must Fix | `schedule_name` のユニットテストが存在しない |
| review-4 | Should Fix | `sanitize` メソッドの可視性不整合 |
| review-5 | Should Fix | `Shellwords.split` が未ハンドルの `ArgumentError` を投げる |
| review-6 | Should Fix | 切り詰め動作がドキュメントされていない |
| review-7 | Nit | 定数がメソッド間に配置されている |
| review-8 | Suggestion | `bundle_command` のクォート付き引数テストが不足 |

## テスト計画
- [x] `rake spec` — 94 examples, 0 failures (+10 新規テスト)
- [x] `rake rubocop` — 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)