### PR TITLE
fix: use update_schedule API for sync and memoize IAM ARN (M2, M3)

### DIFF
--- a/lib/lambda_whenever/event_bridge_scheduler.rb
+++ b/lib/lambda_whenever/event_bridge_scheduler.rb
@@ -96,47 +96,11 @@ module LambdaWhenever
 
     # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Scheduler/Client.html#create_schedule-instance_method
     def create_schedule(target, option)
-      task = target.task
-      name = schedule_name(task, option)
-      @scheduler_client.create_schedule({
-                                          name: name,
-                                          schedule_expression: task.expression,
-                                          schedule_expression_timezone: timezone,
-                                          flexible_time_window: FLEXIBLE_TIME_WINDOW,
-                                          target: {
-                                            arn: target.arn,
-                                            role_arn: IamRole.new(option).arn,
-                                            input: target.input
-                                          },
-                                          group_name: option.scheduler_group,
-                                          state: option.rule_state,
-                                          description: schedule_description(task)
-                                        })
-    rescue Aws::Scheduler::Errors::ValidationException => e
-      Logger.instance.fail("Invalid schedule parameters for '#{name}': #{e.message}.")
-      raise
+      upsert_schedule(:create_schedule, target, option)
     end
 
     def update_schedule(target, option)
-      task = target.task
-      name = schedule_name(task, option)
-      @scheduler_client.update_schedule({
-                                          name: name,
-                                          schedule_expression: task.expression,
-                                          schedule_expression_timezone: timezone,
-                                          flexible_time_window: FLEXIBLE_TIME_WINDOW,
-                                          target: {
-                                            arn: target.arn,
-                                            role_arn: IamRole.new(option).arn,
-                                            input: target.input
-                                          },
-                                          group_name: option.scheduler_group,
-                                          state: option.rule_state,
-                                          description: schedule_description(task)
-                                        })
-    rescue Aws::Scheduler::Errors::ValidationException => e
-      Logger.instance.fail("Invalid schedule parameters for '#{name}': #{e.message}.")
-      raise
+      upsert_schedule(:update_schedule, target, option)
     end
 
     def schedule_name(task, option)
@@ -189,6 +153,28 @@ module LambdaWhenever
       current[:expression] != task.expression ||
         current[:description] != schedule_description(task) ||
         current[:state] != option.rule_state
+    end
+
+    def upsert_schedule(api_method, target, option)
+      task = target.task
+      name = schedule_name(task, option)
+      @scheduler_client.public_send(api_method, {
+                                      name: name,
+                                      schedule_expression: task.expression,
+                                      schedule_expression_timezone: timezone,
+                                      flexible_time_window: FLEXIBLE_TIME_WINDOW,
+                                      target: {
+                                        arn: target.arn,
+                                        role_arn: IamRole.new(option).arn,
+                                        input: target.input
+                                      },
+                                      group_name: option.scheduler_group,
+                                      state: option.rule_state,
+                                      description: schedule_description(task)
+                                    })
+    rescue Aws::Scheduler::Errors::ValidationException => e
+      Logger.instance.fail("Invalid schedule parameters for '#{name}': #{e.message}.")
+      raise
     end
 
     def delete_schedule(name, group_name)

--- a/lib/lambda_whenever/event_bridge_scheduler.rb
+++ b/lib/lambda_whenever/event_bridge_scheduler.rb
@@ -19,6 +19,7 @@ module LambdaWhenever
     def initialize(client, timezone = "UTC")
       @scheduler_client = client
       @timezone = timezone
+      @iam_roles = {}
     end
 
     # NOTE: Calls get_schedule per entry because the ListSchedules API does not return
@@ -165,7 +166,7 @@ module LambdaWhenever
                                       flexible_time_window: FLEXIBLE_TIME_WINDOW,
                                       target: {
                                         arn: target.arn,
-                                        role_arn: IamRole.new(option).arn,
+                                        role_arn: iam_role_arn(option),
                                         input: target.input
                                       },
                                       group_name: option.scheduler_group,
@@ -175,6 +176,11 @@ module LambdaWhenever
     rescue Aws::Scheduler::Errors::ValidationException => e
       Logger.instance.fail("Invalid schedule parameters for '#{name}': #{e.message}.")
       raise
+    end
+
+    def iam_role_arn(option)
+      @iam_roles[option.iam_role] ||= IamRole.new(option)
+      @iam_roles[option.iam_role].arn
     end
 
     def delete_schedule(name, group_name)

--- a/lib/lambda_whenever/event_bridge_scheduler.rb
+++ b/lib/lambda_whenever/event_bridge_scheduler.rb
@@ -76,8 +76,7 @@ module LambdaWhenever
       Logger.instance.message("Updating #{to_update.length} schedules...")
       to_update.each do |desired|
         Logger.instance.message("Updating schedule: #{desired[:name]}")
-        delete_schedule(desired[:name], option.scheduler_group)
-        create_schedule(desired[:target], option)
+        update_schedule(desired[:target], option)
       rescue Aws::Scheduler::Errors::ConflictException
         raise
       rescue Aws::Scheduler::Errors::ServiceError => e
@@ -100,6 +99,28 @@ module LambdaWhenever
       task = target.task
       name = schedule_name(task, option)
       @scheduler_client.create_schedule({
+                                          name: name,
+                                          schedule_expression: task.expression,
+                                          schedule_expression_timezone: timezone,
+                                          flexible_time_window: FLEXIBLE_TIME_WINDOW,
+                                          target: {
+                                            arn: target.arn,
+                                            role_arn: IamRole.new(option).arn,
+                                            input: target.input
+                                          },
+                                          group_name: option.scheduler_group,
+                                          state: option.rule_state,
+                                          description: schedule_description(task)
+                                        })
+    rescue Aws::Scheduler::Errors::ValidationException => e
+      Logger.instance.fail("Invalid schedule parameters for '#{name}': #{e.message}.")
+      raise
+    end
+
+    def update_schedule(target, option)
+      task = target.task
+      name = schedule_name(task, option)
+      @scheduler_client.update_schedule({
                                           name: name,
                                           schedule_expression: task.expression,
                                           schedule_expression_timezone: timezone,

--- a/spec/event_bridge_scheduler_spec.rb
+++ b/spec/event_bridge_scheduler_spec.rb
@@ -414,5 +414,71 @@ RSpec.describe LambdaWhenever::EventBridgeScheduler do
         end.not_to raise_error
       end
     end
+
+    context "when an existing schedule differs" do
+      it "calls update_schedule instead of delete+create" do
+        task = double("Task", name: "task1", expression: "cron(0 12 * * ? *)", commands: [%w[rake run]])
+        target = double("Target", task: task, arn: "arn1", input: "{}")
+
+        desired = [{ name: "task1-hash1", target: target }]
+        current = [{ name: "task1-hash1", expression: "cron(0 0 * * ? *)",
+                     description: task.commands.to_s, state: "ENABLED" }]
+
+        expect(scheduler_client).to receive(:update_schedule).once
+        expect(scheduler_client).not_to receive(:create_schedule)
+        expect(scheduler_client).not_to receive(:delete_schedule)
+
+        scheduler.sync_schedules(desired, current, option)
+      end
+    end
+
+    context "when update_schedule fails with a non-ConflictException" do
+      it "collects errors, continues processing, and raises after all attempts" do
+        task1 = double("Task1", name: "task1", expression: "cron(0 12 * * ? *)", commands: [%w[rake run1]])
+        task2 = double("Task2", name: "task2", expression: "cron(0 18 * * ? *)", commands: [%w[rake run2]])
+        target1 = double("Target1", task: task1, arn: "arn1", input: "{}")
+        target2 = double("Target2", task: task2, arn: "arn2", input: "{}")
+
+        desired = [
+          { name: "task1-hash1", target: target1 },
+          { name: "task2-hash2", target: target2 }
+        ]
+        current = [
+          { name: "task1-hash1", expression: "cron(0 0 * * ? *)",
+            description: task1.commands.to_s, state: "ENABLED" },
+          { name: "task2-hash2", expression: "cron(0 0 * * ? *)",
+            description: task2.commands.to_s, state: "ENABLED" }
+        ]
+
+        call_count = 0
+        allow(scheduler_client).to receive(:update_schedule) do
+          call_count += 1
+          raise Aws::Scheduler::Errors::ValidationException.new(nil, "Invalid") if call_count == 1
+        end
+
+        expect do
+          scheduler.sync_schedules(desired, current, option)
+        end.to raise_error(Aws::Scheduler::Errors::ValidationException)
+        expect(call_count).to eq(2)
+      end
+    end
+
+    context "when update_schedule fails with ConflictException" do
+      it "immediately re-raises for CLI retry handler" do
+        task = double("Task", name: "task1", expression: "cron(0 12 * * ? *)", commands: [%w[rake run]])
+        target = double("Target", task: task, arn: "arn1", input: "{}")
+
+        desired = [{ name: "task1-hash1", target: target }]
+        current = [{ name: "task1-hash1", expression: "cron(0 0 * * ? *)",
+                     description: task.commands.to_s, state: "ENABLED" }]
+
+        allow(scheduler_client).to receive(:update_schedule)
+          .and_raise(Aws::Scheduler::Errors::ConflictException.new(nil, "Concurrent modification"))
+
+        expect do
+          scheduler.sync_schedules(desired, current, option)
+        end.to raise_error(Aws::Scheduler::Errors::ConflictException)
+      end
+    end
   end
 end

--- a/spec/event_bridge_scheduler_spec.rb
+++ b/spec/event_bridge_scheduler_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe LambdaWhenever::EventBridgeScheduler do
 
   describe "#create_schedule" do
     let(:option) do
-      double("Option", key: "test-key", scheduler_group: "test-group", rule_state: "ENABLED")
+      double("Option", key: "test-key", scheduler_group: "test-group", rule_state: "ENABLED", iam_role: "test-role")
     end
     let(:task) { double("Task", name: "my_task", expression: "cron(0 0 * * ? *)", commands: [%w[rake run]]) }
     let(:target) { double("TargetLambda", task: task, arn: "arn:aws:lambda:us-east-1:123:function:test", input: "{}") }
@@ -293,7 +293,7 @@ RSpec.describe LambdaWhenever::EventBridgeScheduler do
 
   describe "#sync_schedules" do
     let(:option) do
-      double("Option", key: "test-key", scheduler_group: "test-group", rule_state: "ENABLED")
+      double("Option", key: "test-key", scheduler_group: "test-group", rule_state: "ENABLED", iam_role: "test-role")
     end
     let(:iam_role) { double("IamRole", arn: "arn:aws:iam::123:role/test") }
 

--- a/spec/event_bridge_scheduler_spec.rb
+++ b/spec/event_bridge_scheduler_spec.rb
@@ -217,6 +217,61 @@ RSpec.describe LambdaWhenever::EventBridgeScheduler do
     end
   end
 
+  describe "#update_schedule" do
+    let(:option) do
+      double("Option", key: "test-key", scheduler_group: "test-group", rule_state: "ENABLED", iam_role: "test-role")
+    end
+    let(:task) { double("Task", name: "my_task", expression: "cron(0 0 * * ? *)", commands: [%w[rake run]]) }
+    let(:target) { double("TargetLambda", task: task, arn: "arn:aws:lambda:us-east-1:123:function:test", input: "{}") }
+    let(:iam_role) { double("IamRole", arn: "arn:aws:iam::123:role/test") }
+
+    before do
+      allow(LambdaWhenever::IamRole).to receive(:new).and_return(iam_role)
+    end
+
+    context "when the API call succeeds" do
+      it "updates a schedule with correct parameters" do
+        expect(scheduler_client).to receive(:update_schedule).with(hash_including(
+                                                                     name: anything,
+                                                                     schedule_expression: "cron(0 0 * * ? *)",
+                                                                     schedule_expression_timezone: "UTC",
+                                                                     flexible_time_window: described_class::FLEXIBLE_TIME_WINDOW,
+                                                                     group_name: "test-group",
+                                                                     state: "ENABLED"
+                                                                   ))
+
+        scheduler.update_schedule(target, option)
+      end
+    end
+
+    context "when ValidationException is raised" do
+      it "logs the error and re-raises" do
+        allow(scheduler_client).to receive(:update_schedule)
+          .and_raise(Aws::Scheduler::Errors::ValidationException.new(nil, "Invalid cron expression"))
+
+        expect(LambdaWhenever::Logger.instance).to receive(:fail)
+          .with(/Invalid schedule parameters.*Invalid cron expression/)
+
+        expect do
+          scheduler.update_schedule(target, option)
+        end.to raise_error(Aws::Scheduler::Errors::ValidationException)
+      end
+    end
+
+    context "when ConflictException is raised" do
+      it "does not catch the error (lets it bubble to CLI retry handler)" do
+        allow(scheduler_client).to receive(:update_schedule)
+          .and_raise(Aws::Scheduler::Errors::ConflictException.new(nil, "Concurrent modification"))
+
+        expect(LambdaWhenever::Logger.instance).not_to receive(:fail)
+
+        expect do
+          scheduler.update_schedule(target, option)
+        end.to raise_error(Aws::Scheduler::Errors::ConflictException)
+      end
+    end
+  end
+
   describe "#list_schedules" do
     context "with pagination" do
       it "retrieves all schedules across multiple pages" do

--- a/spec/event_bridge_scheduler_spec.rb
+++ b/spec/event_bridge_scheduler_spec.rb
@@ -480,5 +480,33 @@ RSpec.describe LambdaWhenever::EventBridgeScheduler do
         end.to raise_error(Aws::Scheduler::Errors::ConflictException)
       end
     end
+
+    context "IamRole caching across multiple operations" do
+      it "creates IamRole only once for multiple create and update calls" do
+        task1 = double("Task1", name: "task1", expression: "cron(0 0 * * ? *)", commands: [%w[rake run1]])
+        task2 = double("Task2", name: "task2", expression: "cron(0 12 * * ? *)", commands: [%w[rake run2]])
+        task3 = double("Task3", name: "task3", expression: "cron(0 18 * * ? *)", commands: [%w[rake run3]])
+        target1 = double("Target1", task: task1, arn: "arn1", input: "{}")
+        target2 = double("Target2", task: task2, arn: "arn2", input: "{}")
+        target3 = double("Target3", task: task3, arn: "arn3", input: "{}")
+
+        desired = [
+          { name: "task1-hash1", target: target1 },
+          { name: "task2-hash2", target: target2 },
+          { name: "task3-hash3", target: target3 }
+        ]
+        current = [
+          { name: "task2-hash2", expression: "cron(0 0 * * ? *)",
+            description: task2.commands.to_s, state: "ENABLED" }
+        ]
+
+        allow(scheduler_client).to receive(:create_schedule)
+        allow(scheduler_client).to receive(:update_schedule)
+
+        expect(LambdaWhenever::IamRole).to receive(:new).once.and_return(iam_role)
+
+        scheduler.sync_schedules(desired, current, option)
+      end
+    end
   end
 end

--- a/spec/iam_role_spec.rb
+++ b/spec/iam_role_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe LambdaWhenever::IamRole do
     end
   end
 
+  describe "#arn caching" do
+    it "caches the ARN after first call" do
+      iam_role = LambdaWhenever::IamRole.new(option)
+      expect(role).to receive(:arn).once.and_return("arn:aws:iam::123456789:role/ecsEventsRole")
+      iam_role.arn
+      iam_role.arn
+    end
+  end
+
   describe "#exists?" do
     it "returns true" do
       expect(LambdaWhenever::IamRole.new(option)).to be_exists


### PR DESCRIPTION
## Summary
- Replace non-atomic delete+create with `update_schedule` API in `sync_schedules` (M3)
- Memoize `IamRole#arn` with `@arn ||=` to avoid redundant AWS API calls per schedule (M2)
- Extract `upsert_schedule` to eliminate code duplication between `create_schedule` and `update_schedule` (C1)
- Cache `IamRole` instance in `EventBridgeScheduler` so memoization is effective across loop iterations (C2)
- Add comprehensive tests for `update_schedule` and `sync_schedules` update path (M1, M2, M3)

## Review findings addressed
| ID | Severity | Description |
|----|----------|-------------|
| M3 | Major | Non-atomic updates in `sync_schedules` — delete+create risks losing schedules on failure |
| M2 | Major | No caching for `IamRole.arn` — fetched via API for every schedule creation |
| C1 | Critical | `create_schedule` and `update_schedule` had identical logic (DRY violation) |
| C2 | Critical | `IamRole.new(option)` called per iteration — instance-level memoization was ineffective |
| M1 | Major | No unit tests for `#update_schedule` |
| M2-test | Major | No tests for `sync_schedules` update path |
| M3-test | Major | ARN caching test only verified instance-level memoization, not actual usage pattern |

## Changes

### `lib/lambda_whenever/event_bridge_scheduler.rb`
- **`upsert_schedule`** (new private method): shared logic extracted from `create_schedule` / `update_schedule`, uses `public_send` to dispatch to the correct AWS API
- **`iam_role_arn`** (new private method): caches `IamRole` instances in `@iam_roles` hash keyed by role name
- **`create_schedule` / `update_schedule`**: now delegate to `upsert_schedule`

### `spec/event_bridge_scheduler_spec.rb`
- **`#update_schedule`**: 3 test cases (success, ValidationException, ConflictException)
- **`#sync_schedules` update path**: 3 test cases (calls update_schedule, error collection, ConflictException re-raise)
- **IamRole caching**: verifies `IamRole.new` is called only once across multiple create and update operations

## Risk
**High** — changes the AWS API path for sync updates. `update_schedule` is an atomic operation; the previous delete+create approach could lose a schedule if create failed after delete.

## IAM policy note
`scheduler:UpdateSchedule` is already listed in the README's required IAM policy.

## Test plan
- [x] `rake spec` — 118 examples, 0 failures (+7 new tests)
- [x] `rake rubocop` — 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)