### PR TITLE
Fix schedule DSL compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ end
 
 The `@environment` variable defaults to `"production"`.
 
+> **Note:** `set :verbose, true` is applied when tasks are created, so it must appear before any `every` blocks you want it to affect.
+
 ## How It Works
 
 Lambda Whenever creates an EventBridge Scheduler schedule for each `every` block. Each schedule can have multiple commands.

--- a/lib/lambda_whenever/schedule.rb
+++ b/lib/lambda_whenever/schedule.rb
@@ -6,8 +6,8 @@ module LambdaWhenever
   class Schedule
     attr_reader :tasks, :chronic_options, :bundle_command, :environment, :timezone
 
-    ALLOWED_SET_KEYS = %w[environment bundle_command chronic_options timezone].freeze
-    RESERVED_SET_KEYS = %w[tasks verbose].freeze
+    ALLOWED_SET_KEYS = %w[environment bundle_command chronic_options timezone verbose].freeze
+    RESERVED_SET_KEYS = %w[tasks].freeze
 
     class UnsupportedFrequencyException < StandardError; end
 
@@ -141,7 +141,7 @@ module LambdaWhenever
 
     def print_tasks
       @tasks.each do |task|
-        Logger.instance.message("#{task.expression} { commands: #{task.commands} }")
+        puts "#{task.expression} { commands: #{task.commands} }"
       end
     end
 
@@ -158,8 +158,8 @@ module LambdaWhenever
       Logger.instance.warn("Skipping unsupported method: #{name}")
     end
 
-    def respond_to_missing?(_name, _include_private = false)
-      true
+    def respond_to_missing?(name, include_private = false)
+      super
     end
   end
 end

--- a/lib/lambda_whenever/task.rb
+++ b/lib/lambda_whenever/task.rb
@@ -38,8 +38,8 @@ module LambdaWhenever
       Logger.instance.warn("Skipping unsupported method: #{name}")
     end
 
-    def respond_to_missing?(_name, _include_private = false)
-      true
+    def respond_to_missing?(name, include_private = false)
+      super
     end
 
     private

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -285,11 +285,11 @@ RSpec.describe LambdaWhenever::Schedule do
   end
 
   describe "#print_tasks" do
-    it "prints tasks via Logger" do
-      logger = LambdaWhenever::Logger.instance
-      expect(logger).to receive(:message).with('cron(0 3 * * ? *) { commands: [["bundle", "exec", "rails", "runner", "-e", "production", "Hoge.run"]] }')
-      expect(logger).to receive(:message).with('cron(0 0 1 * ? *) { commands: [["bundle", "exec", "rake", "hoge:run", "--silent"], ["bundle", "exec", "rails", "runner", "-e", "production", "Fuga.run"]] }')
-      schedule.print_tasks
+    it "prints tasks to stdout" do
+      expect { schedule.print_tasks }.to output(
+        "cron(0 3 * * ? *) { commands: [[\"bundle\", \"exec\", \"rails\", \"runner\", \"-e\", \"production\", \"Hoge.run\"]] }\n" \
+        "cron(0 0 1 * ? *) { commands: [[\"bundle\", \"exec\", \"rake\", \"hoge:run\", \"--silent\"], [\"bundle\", \"exec\", \"rails\", \"runner\", \"-e\", \"production\", \"Fuga.run\"]] }\n"
+      ).to_stdout
     end
   end
 
@@ -300,9 +300,9 @@ RSpec.describe LambdaWhenever::Schedule do
       expect(schedule.tasks).to eq(original_tasks)
     end
 
-    it "rejects reserved key 'verbose'" do
+    it "allows verbose to be set" do
       schedule.set("verbose", true)
-      expect(schedule.instance_variable_get(:@verbose)).to be false
+      expect(schedule.instance_variable_get(:@verbose)).to be true
     end
 
     it "warns about non-standard keys" do


### PR DESCRIPTION
## Summary
- allow "verbose" to be set from the schedule DSL again
- restore dryrun output to the original stdout format
- make respond_to? behave normally by removing the always-true override
- document that `set :verbose` must appear before `every`

## Rationale
- The schedule DSL previously allowed `set :verbose`, and blocking it is a behavior regression that breaks existing schedules relying on the flag to control `--silent`.
- Switching `print_tasks` to Logger prepended `## [message]`, which is a user-visible output change and can break scripts that parse dryrun output.
- `respond_to_missing?` always returning true hides typos and can cause callers that check `respond_to?` to take incorrect paths.
- `set :verbose` is applied when tasks are created, so the ordering requirement is documented to avoid confusion.

## Testing
Finished in 5.39 seconds (files took 0.26822 seconds to load)
162 examples, 0 failures
